### PR TITLE
More informative message if name of unattached component is not available

### DIFF
--- a/src/ComponentModel/Component.php
+++ b/src/ComponentModel/Component.php
@@ -66,7 +66,10 @@ abstract class Component implements IComponent
 		}
 
 		if ($throw && $this->monitors[$type][0] === null) {
-			throw new Nette\InvalidStateException("Component '$this->name' is not attached to '$type'.");
+			$message = $this->name !== null
+				? "Component '$this->name' is not attached to '$type'."
+				: "Component of type '" . static::class . "' is not attached to '$type'.";
+			throw new Nette\InvalidStateException($message);
 		}
 
 		return $this->monitors[$type][0];


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: not needed

Every single time I see component is not attached it is exactly `Component '' is not attached to 'Nette\Application\UI\Presenter'.`.

...which component?

With proposed change it would at least inform about type of unattached component.
`Component of type 'Foo\Bar\Baz' is not attached to 'Nette\Application\UI\Presenter'.`