### PR TITLE
Container: fixed var name ($component => $this)

### DIFF
--- a/src/ComponentModel/Container.php
+++ b/src/ComponentModel/Container.php
@@ -107,7 +107,7 @@ class Container extends Component implements IContainer
 	final public function getComponent(string $name, bool $throw = true): ?IComponent
 	{
 		if (!$throw) {
-			return $component->getComponentIfExists($name);
+			return $this->getComponentIfExists($name);
 		}
 
 		[$name] = $parts = explode(self::NAME_SEPARATOR, $name, 2);


### PR DESCRIPTION
- bug fix
- BC break? no

Looks like a typo, $component variable is not declared.