### PR TITLE
Fix PHP 8.5 deprecation (null as an array offset)

### DIFF
--- a/src/ComponentModel/Container.php
+++ b/src/ComponentModel/Container.php
@@ -65,7 +65,7 @@ class Container extends Component implements IContainer
 		// user checking
 		$this->validateChildComponent($component);
 
-		if (isset($this->components[$insertBefore])) {
+		if ($insertBefore !== null && isset($this->components[$insertBefore])) {
 			$tmp = [];
 			foreach ($this->components as $k => $v) {
 				if ((string) $k === $insertBefore) {


### PR DESCRIPTION
- bug fix for PHP 8.5 support
- BC break? no
- doc PR: not needed

Fixes deprecation warning on PHP 8.5:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead
```
